### PR TITLE
Add iloc for indexing when getting terminal ID

### DIFF
--- a/Chapter_3_GettingStarted/BaselineFeatureTransformation.ipynb
+++ b/Chapter_3_GettingStarted/BaselineFeatureTransformation.ipynb
@@ -1944,7 +1944,7 @@
     {
      "data": {
       "text/plain": [
-       "3156"
+       "3059"
       ]
      },
      "execution_count": 16,
@@ -1954,7 +1954,7 @@
    ],
    "source": [
     "# Get the first terminal ID that contains frauds\n",
-    "transactions_df[transactions_df.TX_FRAUD==0].TERMINAL_ID[0]"
+    "transactions_df[transactions_df.TX_FRAUD==1].TERMINAL_ID.iloc[0]"
    ]
   },
   {


### PR DESCRIPTION
The line:
```
transactions_df[transactions_df.TX_FRAUD==1].TERMINAL_ID.iloc[0]
```
Fails if the transaction with an index of `0` within `transactions_df` is not identified as fraudulent. 

I also updated the code from `transactions_df.TX_FRAUD==0` to `transactions_df.TX_FRAUD==1` to reflect the text and changed the output to the correct value of `3059`.

The following cell used the correct `TERMINAL_ID` of `3059`, so no further changes were required.