### PR TITLE
Fix apparently disordered subsections in chapter 3 section 2

### DIFF
--- a/Chapter_3_GettingStarted/SimulatedDataset.ipynb
+++ b/Chapter_3_GettingStarted/SimulatedDataset.ipynb
@@ -46,6 +46,31 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<h4>Transaction generation process</h4>\n",
+    "\n",
+    "The simulation will consist of five main steps:\n",
+    "\n",
+    "1. Generation of customer profiles: Every customer is different in their spending habits. This will be simulated by defining some properties for each customer. The main properties will be their geographical location, their spending frequency, and their spending amounts. The customer properties will be represented as a table, referred to as the *customer profile table*. \n",
+    "2. Generation of terminal profiles: Terminal properties will simply consist of a geographical location. The terminal properties will be represented as a table, referred to as the *terminal profile table*.\n",
+    "3. Association of customer profiles to terminals: We will assume that customers only make transactions on terminals that are within a radius of $r$ of their geographical locations. This makes the simple assumption that a customer only makes transactions on terminals that are geographically close to their location. This step will consist of adding a feature 'list_terminals' to each customer profile, that contains the set of terminals that a customer can use.\n",
+    "4. Generation of transactions: The simulator will loop over the set of customer profiles, and generate transactions according to their properties (spending frequencies and amounts, and available terminals). This will result in a table of transactions.\n",
+    "5. Generation of fraud scenarios: This last step will label the transactions as legitimate or genuine. This will be done by following three different fraud scenarios.\n",
+    "\n",
+    "The transaction generation process is illustrated below. \n",
+    "\n",
+    "![alt text](images/FlowDatasetGenerator.png)\n",
+    "<p style=\"text-align: center;\">\n",
+    "Fig. 2. Transaction generation process. The customer and terminal profiles are used to generate  <br> a set of transactions. The final step, which generates fraud scenarios, provides the labeled transactions table.\n",
+    "   \n",
+    "\n",
+    "The following sections detail the implementation for each of these steps. \n",
+    "    "
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
@@ -89,31 +114,6 @@
     "* `mean_nb_tx_per_day`:  The average number of transactions per day for the customer, assuming that the number of transactions per day follows a Poisson distribution. This number will be drawn from a uniform distribution (0,4). \n",
     "\n",
     "The `generate_customer_profiles_table` function provides an implementation for generating a table of customer profiles. It takes as input the number of customers for which to generate a profile and a random state for reproducibility. It returns a DataFrame containing the properties for each customer. "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<h4>Transaction generation process</h4>\n",
-    "\n",
-    "The simulation will consist of five main steps:\n",
-    "\n",
-    "1. Generation of customer profiles: Every customer is different in their spending habits. This will be simulated by defining some properties for each customer. The main properties will be their geographical location, their spending frequency, and their spending amounts. The customer properties will be represented as a table, referred to as the *customer profile table*. \n",
-    "2. Generation of terminal profiles: Terminal properties will simply consist of a geographical location. The terminal properties will be represented as a table, referred to as the *terminal profile table*.\n",
-    "3. Association of customer profiles to terminals: We will assume that customers only make transactions on terminals that are within a radius of $r$ of their geographical locations. This makes the simple assumption that a customer only makes transactions on terminals that are geographically close to their location. This step will consist of adding a feature 'list_terminals' to each customer profile, that contains the set of terminals that a customer can use.\n",
-    "4. Generation of transactions: The simulator will loop over the set of customer profiles, and generate transactions according to their properties (spending frequencies and amounts, and available terminals). This will result in a table of transactions.\n",
-    "5. Generation of fraud scenarios: This last step will label the transactions as legitimate or genuine. This will be done by following three different fraud scenarios.\n",
-    "\n",
-    "The transaction generation process is illustrated below. \n",
-    "\n",
-    "![alt text](images/FlowDatasetGenerator.png)\n",
-    "<p style=\"text-align: center;\">\n",
-    "Fig. 2. Transaction generation process. The customer and terminal profiles are used to generate  <br> a set of transactions. The final step, which generates fraud scenarios, provides the labeled transactions table.\n",
-    "   \n",
-    "\n",
-    "The following sections detail the implementation for each of these steps. \n",
-    "    "
    ]
   },
   {


### PR DESCRIPTION
The subsection `Transaction generation process` appears in the section `2.1. Customer profiles generation` but it seems more logical to me that it should appear in the earlier section `Design choices`.