### PR TITLE
Fix color code in text, chapter 3 section 2.3

### DIFF
--- a/Chapter_3_GettingStarted/SimulatedDataset.ipynb
+++ b/Chapter_3_GettingStarted/SimulatedDataset.ipynb
@@ -581,8 +581,8 @@
    "source": [
     "For better visualization, let us plot \n",
     "\n",
-    "* The locations of all terminals (in red)\n",
-    "* The location of the last customer (in blue)\n",
+    "* The locations of all terminals (in blue)\n",
+    "* The location of the last customer (in red)\n",
     "* The region within radius of 50 of the first customer (in green)"
    ]
   },


### PR DESCRIPTION
The color code used in the example plot of terminals within a customer's radius does not match with the text (red and blue are inverted).