### PR TITLE
Fix parallel function name typo in Chapter 3 Section 2.4

### DIFF
--- a/Chapter_3_GettingStarted/SimulatedDataset.ipynb
+++ b/Chapter_3_GettingStarted/SimulatedDataset.ipynb
@@ -1347,7 +1347,7 @@
     "    x_y_terminals = terminal_profiles_table[['x_terminal_id','y_terminal_id']].values.astype(float)\n",
     "    customer_profiles_table['available_terminals'] = customer_profiles_table.apply(lambda x : get_list_terminals_within_radius(x, x_y_terminals=x_y_terminals, r=r), axis=1)\n",
     "    # With Pandarallel\n",
-    "    #customer_profiles_table['available_terminals'] = customer_profiles_table.parallel_apply(lambda x : get_list_closest_terminals(x, x_y_terminals=x_y_terminals, r=r), axis=1)\n",
+    "    #customer_profiles_table['available_terminals'] = customer_profiles_table.parallel_apply(lambda x : get_list_terminals_within_radius(x, x_y_terminals=x_y_terminals, r=r), axis=1)\n",
     "    customer_profiles_table['nb_terminals']=customer_profiles_table.available_terminals.apply(len)\n",
     "    print(\"Time to associate terminals to customers: {0:.2}s\".format(time.time()-start_time))\n",
     "    \n",


### PR DESCRIPTION
The parallel_apply function in customer_profiles_table[ 'available_terminals' ] uses `get_list_closest_terminals`, a function which doesn't exist. Although its a comment, I figured the correct function would be `get_list_terminals_within_radius`.