### PR TITLE
replacing "append" with "pd.concat"

### DIFF
--- a/Chapter_3_GettingStarted/BaselineModeling.ipynb
+++ b/Chapter_3_GettingStarted/BaselineModeling.ipynb
@@ -1260,7 +1260,7 @@
     "                                                   prediction_feature='predictions', top_k_list=top_k_list)\n",
     "        performances_model.index=[classifier_name]\n",
     "        \n",
-    "        performances=performances.append(performances_model)\n",
+    "        performances=pd.concat([performances, performances_model], ignore_index=False)\n",
     "        \n",
     "    return performances"
    ]


### PR DESCRIPTION
performances.append(performances_model) is outdated, but can be replaced with pd.concat([performances, performances_model], ignore_index= False)